### PR TITLE
Converting int to float to increase upperlimit

### DIFF
--- a/FinalProject--Python.py
+++ b/FinalProject--Python.py
@@ -195,9 +195,9 @@ def calculate():
 
     at = e5.get()
     ad = e6.get()
-    ta = int(at) - int(ad)
+    ta = float(at) - float(ad)
     old = oldtax(ta)
-    new = newtax(int(at))
+    new = newtax(float(at))
     tax_save = abs(new - old)
     tax_save = round(tax_save, 2)
     if new > old:


### PR DESCRIPTION
I have changed the datatype from float to int and that means any number tending to 3.402823466E+38 should successfully run in the program.
Any error in the processing of larger numbers is due to the shortcomings of the computer system.
Furthermore, it will take longer to process the program due to the low efficiency of the program with an increase in each power of 10 of the input value.